### PR TITLE
Fixed bug causing segfault while printing automata

### DIFF
--- a/Automata/PrintAut.C
+++ b/Automata/PrintAut.C
@@ -79,7 +79,7 @@ static void QM(MultiMap::const_iterator iter, unsigned count, unsigned num, Impl
   }
   
   while(!iset.empty()) {
-    for(ImplicantSet::iterator i=iset.begin(); i!=iset.end(); ++i) {
+    for(ImplicantSet::iterator i=iset.begin(); i!=iset.end(); ) {
       bool joined=false;
       for (ImplicantSet::iterator j=i; j!=iset.end(); ++j) { 
 	if((*i).joinable(*j)) {
@@ -95,6 +95,7 @@ static void QM(MultiMap::const_iterator iter, unsigned count, unsigned num, Impl
 	covering.insert(*i);
       }
       ImplicantSet::iterator it=i;
+      ++i;
       iset.erase(it);
     }
   } 


### PR DESCRIPTION
Hi Scott,

I've been using your fork of scheck in my graduate research, and I recently noticed that it segfaults on any output while printing the automaton. (I assume there was an change in the underlying C++ set implementation that enforces iterator validity more strictly than previously.) This fixes that bug.

Thanks for providing this fork -- it's been extremely useful for my LTL-related research!

Best,
Daniel